### PR TITLE
change: Split `__init__.py` to multiple files

### DIFF
--- a/dbt_superset_lineage/__init__.py
+++ b/dbt_superset_lineage/__init__.py
@@ -7,8 +7,8 @@ app = typer.Typer()
 @app.command()
 def pull_dashboards(dbt_project_dir: str = typer.Option('.', help=""),
                     exposures_path: str = typer.Option('/models/exposures/superset_dashboards.yml',
-                                                          help="If you change this, the path needs to be added"
-                                                               "to source-paths in dbt_project.yml."),
+                                                       help="If you change this, the path needs to be added"
+                                                            "to source-paths in dbt_project.yml."),
                     dbt_db_name: str = typer.Option(None, help=""),
                     superset_url: str = typer.Argument(..., help=""),
                     superset_db_id: int = typer.Option(None, help=""),

--- a/dbt_superset_lineage/pull_dashboards.py
+++ b/dbt_superset_lineage/pull_dashboards.py
@@ -53,7 +53,7 @@ def get_tables_from_dbt(dbt_catalog, dbt_db_name):
     for table_type in ['nodes', 'sources']:
         catalog_subset = dbt_catalog[table_type]
 
-        for table in list(catalog_subset.keys()):
+        for table in catalog_subset:
             name = catalog_subset[table]['metadata']['name']
             schema = catalog_subset[table]['metadata']['schema']
             database = catalog_subset[table]['metadata']['database']


### PR DESCRIPTION
In preparation for a second command and to allow for easier orientation between the two, each Typer command should be put to a separate `.py` file.

Note that this is to be merged to #1.