### PR TITLE
Feature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ as environment variable or through `--superset-access-token`/`superset-refresh-t
 **N.B.**
 - Make sure to run `dbt compile` (or `dbt run`) against the production profile, not your development profile  
 - In case more databases are used within dbt and/or Superset and there are duplicate names (`schema + table`) across
-  them, specify the database through `--dbt-db-name` and/or `--superset-db-id` options
+  them, specify the database through `--dbt-db-name` and/or `--superset-db-id` options and/or `--superset-db-name` and/or ``--superset-schema-name``
 - Currently, `PUT` requests are only supported if CSRF tokens are disabled in Superset (`WTF_CSRF_ENABLED=False`).
 - Tested on dbt v0.20.0 and Apache Superset v1.3.0. Other versions, esp. those newer of Superset, might face errors due
   to different underlying code and API.
@@ -62,6 +62,8 @@ references to dbt sources and models, making them visible both separately and as
 
 **N.B.**
 - Only published dashboards are extracted.
+- Alternatively, setting `--superset-dashboard-name` will pull the dashboard of this name, published or unpublished. 
+- Multiple can be set as `--superset-dashboard-name 'Name One' --superset-dashboard-name 'Name 2'`
 
 ```console
 $ cd jaffle_shop
@@ -84,6 +86,7 @@ in Superset when creating charts.
 - Run carefully as this rewrites your datasets using merged column metadata from Superset and dbt docs.
 - Descriptions are rendered as plain text, hence no markdown syntax, incl. links, will be displayed.
 - Avoid special characters and strings in your dbt docs, e.g. `→` or `<null>`.
+- You can set the superset database by id or name, as well as the specific schema with `--superset-db-id` and/or `--superset-db-name` and/or ``--superset-schema-name``
 
 
 ```console

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ in Superset when creating charts.
 - Run carefully as this rewrites your datasets using merged column metadata from Superset and dbt docs.
 - Descriptions are rendered as plain text, hence no markdown syntax, incl. links, will be displayed.
 - Avoid special characters and strings in your dbt docs, e.g. `→` or `<null>`.
-- You can set the superset database by id or name, as well as the specific schema with `--superset-db-id` and/or `--superset-db-name` and/or ``--superset-schema-name``
+- You can set the superset database by id or name, as well as the specific schema with `--superset-db-id` and/or `--superset-db-name` and/or `--superset-schema-name`
 
 
 ```console

--- a/dbt_superset_lineage/__init__.py
+++ b/dbt_superset_lineage/__init__.py
@@ -1,4 +1,5 @@
 import typer
+from typing import List
 from .pull_dashboards import main as pull_dashboards_main
 from .push_descriptions import main as push_descriptions_main
 
@@ -26,11 +27,15 @@ def pull_dashboards(dbt_project_dir: str = typer.Option('.', help="Directory pat
                                                                    "Can be automatically generated if "
                                                                    "SUPERSET_REFRESH_TOKEN is provided."),
                     superset_refresh_token: str = typer.Option(None, envvar="SUPERSET_REFRESH_TOKEN",
-                                                               help="Refresh token to Superset API.")):
+                                                               help="Refresh token to Superset API."),
+                    superset_dashboard_name:List[str] = typer.Option(None,help="List dashboards you want import by Name."
+                                                                      "Each Dashboard should be a separate param."
+                                                                      "ex. --superset-dashboard-name 'Name One' --superset-dashboard-name 'Name 2'")):
 
     pull_dashboards_main(dbt_project_dir, exposures_path, dbt_db_name,
                          superset_url, superset_db_id, sql_dialect,
-                         superset_access_token, superset_refresh_token)
+                         superset_access_token, superset_refresh_token,
+                         superset_dashboard_name)
 
 
 @app.command()
@@ -49,11 +54,16 @@ def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory p
                                                                      "Can be automatically generated if "
                                                                      "SUPERSET_REFRESH_TOKEN is provided."),
                       superset_refresh_token: str = typer.Option(None, envvar="SUPERSET_REFRESH_TOKEN",
-                                                                 help="Refresh token to Superset API.")):
+                                                                 help="Refresh token to Superset API."),
+                      superset_db_name: str = typer.Option(None, help="Name of your database within Superset towards which "
+                                                                                "the push should be reduced to run."),
+                      superset_schema_name: str = typer.Option(None, help="Name of your database schema within Superset towards which "
+                                                                                "the push should be reduced to run.")):
 
     push_descriptions_main(dbt_project_dir, dbt_db_name,
                            superset_url, superset_db_id, superset_refresh_columns,
-                           superset_access_token, superset_refresh_token)
+                           superset_access_token, superset_refresh_token,
+                           superset_db_name,superset_schema_name)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-superset-lineage"
-version = "0.2.1"
+version = "0.2.2"
 description = "Make dbt docs and Apache Superset talk to one another"
 authors = ["Michal Kolacek <mkolacek@slido.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Problems:

1. We wanted to pull dashboards by name and not simply by published status
2. When pushing, we wanted to specify the database by name.
3.  When pushing, we wanted to specify the schema name in case of inter-schema table name overlap.

### Solutions:

1. Added: `--superset-dashboard-name` as a option for pulling. It can be daisy chained by using `--superset-dashboard-name 'Name One' --superset-dashboard-name 'Name 2'`. 
2. Added: `--superset-db-name` to push command
3. Added: `--superset-schema-name` to push command

Updated the docs to reflect  these changes.