### PR TITLE
Revert "Fix: Replace `params` with `json` for `superset.request`"

### DIFF
--- a/dbt_superset_lineage/pull_dashboards.py
+++ b/dbt_superset_lineage/pull_dashboards.py
@@ -95,7 +95,7 @@ def get_dashboards_from_superset(superset, superset_url, superset_db_id):
                 'page_size': 100
             }
         }
-        res = superset.request('GET', '/dashboard/', json=payload)
+        res = superset.request('GET', '/dashboard/', params=payload)
 
         result = res['result']
         if result:
@@ -179,7 +179,7 @@ def get_datasets_from_superset(superset, dashboards_datasets, dbt_tables,
                 'page_size': 100
             }
         }
-        res = superset.request('GET', '/dataset/', json=payload)
+        res = superset.request('GET', '/dataset/', params=payload)
 
         result = res['result']
         if result:

--- a/dbt_superset_lineage/push_descriptions.py
+++ b/dbt_superset_lineage/push_descriptions.py
@@ -26,7 +26,7 @@ def get_datasets_from_superset(superset, superset_db_id):
                 'page_size': 100
             }
         }
-        res = superset.request('GET', '/dataset/', json=payload)
+        res = superset.request('GET', '/dataset/', params=payload)
 
         result = res['result']
         if result:
@@ -175,8 +175,8 @@ def merge_columns_info(dataset, tables):
 def put_columns_to_superset(superset, dataset):
     logging.info("Putting new columns info with descriptions back into Superset.")
 
-    payload = {'columns': dataset['columns_new']}
-    superset.request('PUT', f"/dataset/{dataset['id']}?override_columns=true", json=payload)
+    body = {'columns': dataset['columns_new']}
+    superset.request('PUT', f"/dataset/{dataset['id']}?override_columns=true", json=body)
 
 
 def main(dbt_project_dir, dbt_db_name,


### PR DESCRIPTION
Reverts slidoapp/dbt-superset-lineage#17 as it turns out this was not the underlying issue.