### PR TITLE
Fix incorrect parsing of payload

### DIFF
--- a/dbt_superset_lineage/pull_dashboards.py
+++ b/dbt_superset_lineage/pull_dashboards.py
@@ -90,10 +90,10 @@ def get_dashboards_from_superset(superset, superset_url, superset_db_id):
         logging.info("Getting page %d.", page_number + 1)
 
         payload = {
-            'q': {
+            'q': json.dumps({
                 'page': page_number,
                 'page_size': 100
-            }
+            })
         }
         res = superset.request('GET', '/dashboard/', params=payload)
 
@@ -174,10 +174,10 @@ def get_datasets_from_superset(superset, dashboards_datasets, dbt_tables,
         logging.info("Getting page %d.", page_number + 1)
 
         payload = {
-            'q': {
+            'q': json.dumps({
                 'page': page_number,
                 'page_size': 100
-            }
+            })
         }
         res = superset.request('GET', '/dataset/', params=payload)
 

--- a/dbt_superset_lineage/push_descriptions.py
+++ b/dbt_superset_lineage/push_descriptions.py
@@ -21,10 +21,10 @@ def get_datasets_from_superset(superset, superset_db_id):
         logging.info("Getting page %d.", page_number + 1)
 
         payload = {
-            'q': {
+            'q': json.dumps({
                 'page': page_number,
                 'page_size': 100
-            }
+            })
         }
         res = superset.request('GET', '/dataset/', params=payload)
 


### PR DESCRIPTION
It was believed that `requests` serialises a dictionary into JSON but that doesn't seem to be the case.