### PR TITLE
Update the way exposures are saved

### DIFF
--- a/dbt_superset_lineage/pull_dashboards.py
+++ b/dbt_superset_lineage/pull_dashboards.py
@@ -243,7 +243,7 @@ def get_exposures_dict(dashboards, exposures):
     exposures_dict = [{
         # remove non-word characters (unless it's space) and replace spaces with underscores
         # required since dbt v1.3
-        'name': re.sub(r'[^\w\s]+', '', dashboard['title']).replace(' ', '_'),
+        'name': re.sub(r'[^\w ]+', '', dashboard['title']).replace(' ', '_'),
         'label': dashboard['title'],
         'type': 'dashboard',
         'url': dashboard['url'],

--- a/dbt_superset_lineage/pull_dashboards.py
+++ b/dbt_superset_lineage/pull_dashboards.py
@@ -241,7 +241,10 @@ def get_exposures_dict(dashboards, exposures):
 
     exposures_orig = {exposure['url']: exposure for exposure in exposures}
     exposures_dict = [{
-        'name': dashboard['title'],
+        # remove non-word characters (unless it's space) and replace spaces with underscores
+        # required since dbt v1.3
+        'name': re.sub(r'[^\w\s]+', '', dashboard['title']).replace(' ', '_'),
+        'label': dashboard['title'],
         'type': 'dashboard',
         'url': dashboard['url'],
         # get descriptions from original file through url (unique as it's based on dashboard id)


### PR DESCRIPTION
Starting in dbt v1.3, the 'name' of an exposure should contain only letters, numbers, and underscores. Exposures support a new property, 'label', which may contain spaces, capital letters, and special characters.