### PR TITLE
Fix `put_descriptions_to_superset` overwriting columns

### DIFF
--- a/dbt_superset_lineage/push_descriptions.py
+++ b/dbt_superset_lineage/push_descriptions.py
@@ -206,7 +206,7 @@ def put_descriptions_to_superset(superset, dataset):
     if description_new != description_old or \
        not check_columns_equal(columns_new, columns_old):
         payload = {'description': description_new, 'columns': columns_new}
-        superset.request('PUT', f"/dataset/{dataset['id']}?override_columns=true", json=payload)
+        superset.request('PUT', f"/dataset/{dataset['id']}?override_columns=false", json=payload)
     else:
         logging.info("Skipping PUT execute request as nothing would be updated.")
 


### PR DESCRIPTION
One of the changes introduced in `v0.3.0` was to only push column descriptions with other mandatory fields, i.e. not all fields. Everything else should stay untouched which can be easily achieved by setting `override_columns` to `false`, instead of `true`.