### PR TITLE
Add optional parameter `superset_pause_after_put`

### DIFF
--- a/dbt_superset_lineage/__init__.py
+++ b/dbt_superset_lineage/__init__.py
@@ -43,10 +43,11 @@ def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory p
                       superset_refresh_columns: bool = typer.Option(False, help="Whether columns in Superset should be "
                                                                                 "refreshed from database before "
                                                                                 "the push."),
-                      superset_pause_after_put: int = typer.Option(None, help="Number of seconds for which the script "
-                                                                              "pauses after a PUT call on Superset "
-                                                                              "API. This is to allow databases to "
-                                                                              "update in the meantime."),
+                      superset_pause_after_update: int = typer.Option(None, help="Number of seconds for which the "
+                                                                                 "script pauses after any update of "
+                                                                                 "Superset columns. This is to allow "
+                                                                                 "databases to catch up in "
+                                                                                 "the meantime."),
                       superset_access_token: str = typer.Option(None, envvar="SUPERSET_ACCESS_TOKEN",
                                                                 help="Access token to Superset API."
                                                                      "Can be automatically generated if "
@@ -55,7 +56,7 @@ def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory p
                                                                  help="Refresh token to Superset API.")):
 
     push_descriptions_main(dbt_project_dir, dbt_db_name,
-                           superset_url, superset_db_id, superset_refresh_columns, superset_pause_after_put,
+                           superset_url, superset_db_id, superset_refresh_columns, superset_pause_after_update,
                            superset_access_token, superset_refresh_token)
 
 

--- a/dbt_superset_lineage/__init__.py
+++ b/dbt_superset_lineage/__init__.py
@@ -43,6 +43,10 @@ def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory p
                       superset_refresh_columns: bool = typer.Option(False, help="Whether columns in Superset should be "
                                                                                 "refreshed from database before "
                                                                                 "the push."),
+                      superset_pause_after_put: int = typer.Option(None, help="Number of seconds for which the script "
+                                                                              "pauses after a PUT call on Superset "
+                                                                              "API. This is to allow databases to "
+                                                                              "update in the meantime."),
                       superset_access_token: str = typer.Option(None, envvar="SUPERSET_ACCESS_TOKEN",
                                                                 help="Access token to Superset API."
                                                                      "Can be automatically generated if "
@@ -51,7 +55,7 @@ def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory p
                                                                  help="Refresh token to Superset API.")):
 
     push_descriptions_main(dbt_project_dir, dbt_db_name,
-                           superset_url, superset_db_id, superset_refresh_columns,
+                           superset_url, superset_db_id, superset_refresh_columns, superset_pause_after_put,
                            superset_access_token, superset_refresh_token)
 
 

--- a/dbt_superset_lineage/push_descriptions.py
+++ b/dbt_superset_lineage/push_descriptions.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import time
 
 from bs4 import BeautifulSoup
 from markdown import markdown
@@ -196,7 +197,14 @@ def check_columns_equal(lst1, lst2):
     return sorted(lst1, key=lambda c: c["id"]) == sorted(lst2, key=lambda c: c["id"])
 
 
-def put_descriptions_to_superset(superset, dataset):
+def pause_after_put(superset_pause_after_put):
+    if superset_pause_after_put:
+        logging.info("Pausing the script for %d seconds to allow for databases to update.", superset_pause_after_put)
+        time.sleep(superset_pause_after_put)
+        logging.info("Resuming the script again.")
+
+
+def put_descriptions_to_superset(superset, dataset, superset_pause_after_put):
     logging.info("Putting model and column descriptions into Superset.")
 
     description_new = dataset['description_new']
@@ -214,12 +222,13 @@ def put_descriptions_to_superset(superset, dataset):
        not check_columns_equal(columns_new, columns_old):
         payload = {'description': description_new, 'columns': columns_new, 'owners': owners_new}
         superset.request('PUT', f"/dataset/{dataset['id']}?override_columns=false", json=payload)
+        pause_after_put(superset_pause_after_put)
     else:
         logging.info("Skipping PUT execute request as nothing would be updated.")
 
 
 def main(dbt_project_dir, dbt_db_name,
-         superset_url, superset_db_id, superset_refresh_columns,
+         superset_url, superset_db_id, superset_refresh_columns, superset_pause_after_put,
          superset_access_token, superset_refresh_token):
 
     # require at least one token for Superset
@@ -250,9 +259,10 @@ def main(dbt_project_dir, dbt_db_name,
         try:
             if superset_refresh_columns:
                 refresh_columns_in_superset(superset, sst_dataset_id)
+                pause_after_put(superset_pause_after_put)
             sst_dataset_w_cols = add_superset_columns(superset, sst_dataset)
             sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables)
-            put_descriptions_to_superset(superset, sst_dataset_w_cols_new)
+            put_descriptions_to_superset(superset, sst_dataset_w_cols_new, superset_pause_after_put)
         except HTTPError as e:
             logging.error("The dataset with ID=%d wasn't updated. Check the error below.",
                           sst_dataset_id, exc_info=e)


### PR DESCRIPTION
It turns out that `PUT` calls on Superset API strain its databases as they need to update the columns everywhere upon change. This allows users to optionally pause for a couple of seconds before making the next `PUT` call.