### PR TITLE
Add option to specify the database schema in addition to 'database' (e.g. for starrocks)

### DIFF
--- a/dbt_superset_lineage/__init__.py
+++ b/dbt_superset_lineage/__init__.py
@@ -13,6 +13,8 @@ def pull_dashboards(dbt_project_dir: str = typer.Option('.', help="Directory pat
                                                             "needs to be added to source-paths in dbt_project.yml."),
                     dbt_db_name: str = typer.Option(None, help="Name of your database within dbt towards which "
                                                                "the pull should be reduced to run."),
+                    dbt_schema_name: str = typer.Option(None, help="Name of your schema within dbt towards which "
+                                                            "the pull should be reduced to run."),
                     superset_url: str = typer.Argument(..., help="URL of your Superset, e.g. "
                                                                  "https://mysuperset.mycompany.com"),
                     superset_db_id: int = typer.Option(None, help="ID of your database within Superset towards which "
@@ -28,14 +30,17 @@ def pull_dashboards(dbt_project_dir: str = typer.Option('.', help="Directory pat
                                                                help="Refresh token to Superset API.")):
 
     pull_dashboards_main(dbt_project_dir, exposures_path, dbt_db_name,
-                         superset_url, superset_db_id, sql_dialect,
-                         superset_access_token, superset_refresh_token)
+                         dbt_schema_name, superset_url, superset_db_id,
+                         sql_dialect, superset_access_token,
+                         superset_refresh_token)
 
 
 @app.command()
 def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory path to dbt project."),
                       dbt_db_name: str = typer.Option(None, help="Name of your database within dbt to which the script "
                                                                  "should be reduced to run."),
+                      dbt_schema_name: str = typer.Option(None, help="Name of your schema within dbt towards which "
+                                                            "the pull should be reduced to run."),
                       superset_url: str = typer.Argument(..., help="URL of your Superset, e.g. "
                                                                    "https://mysuperset.mycompany.com"),
                       superset_db_id: int = typer.Option(None, help="ID of your database within Superset towards which "
@@ -55,7 +60,7 @@ def push_descriptions(dbt_project_dir: str = typer.Option('.', help="Directory p
                       superset_refresh_token: str = typer.Option(None, envvar="SUPERSET_REFRESH_TOKEN",
                                                                  help="Refresh token to Superset API.")):
 
-    push_descriptions_main(dbt_project_dir, dbt_db_name,
+    push_descriptions_main(dbt_project_dir, dbt_db_name, dbt_schema_name,
                            superset_url, superset_db_id, superset_refresh_columns, superset_pause_after_update,
                            superset_access_token, superset_refresh_token)
 


### PR DESCRIPTION
I am currently running dbt, superset and apache starrocks (I know it's kinda niche) and want to also use dbt-superset-lineage for this. In starrocks, there is no such thing as a `database`, there's **only** a `schema`. Therefore, I have to specify my dbt models like this:

```
sources:
  - name: data
    schema: ...
```

specifying my models like this

```
sources:
  - name: data
    database: ...
```
would raise an error in dbt. dbt-superset-lineage doesn't work as of now as it only reads the `database` key in the yaml file and can't find the tables as `database` is `None`

In this PR I have added the option to specify a `database` or a `schema`.
- When both database and schema are given (like e.g. in postgres), only this combination will be pulled from.
- When either of the 2 are given we ignore the other (like in starrocks where schema would be given but database ignored)
- When none are given, we pull from all tables.

This also gives people more fine-grained control when they work with a DWH that has `schema` and `database`